### PR TITLE
fix(unitable): run structure inference under torch.inference_mode

### DIFF
--- a/rapid_doc/model/table/rapid_table_self/table_structure/unitable/main.py
+++ b/rapid_doc/model/table/rapid_table_self/table_structure/unitable/main.py
@@ -56,6 +56,7 @@ class UniTableStructure:
 
         self.preprocess_op = TablePreprocess(self.device)
 
+    @torch.inference_mode()
     def __call__(self, imgs: List[np.ndarray]):
         img_batch, ori_shapes = self.preprocess_op(imgs)
         memory_batch = self.encoder(img_batch)


### PR DESCRIPTION
## Problem

`UniTableStructure.__call__` builds a full autograd graph on every request. The torch engine calls `model.eval()`, but `eval()` only switches dropout/batch-norm behavior — it does not disable gradient tracking, and the model parameters keep `requires_grad=True`. Because the decoder's KV caches (`setup_caches`) persist on the module between calls and reference graph-connected tensors, **each call's entire autograd graph stays reachable forever**.

In a long-running service this is an unbounded leak. Measured on current `main` (v0.9.9, CPU, torch 2.13, identical synthetic table input per call):

| after call | tensors with live `grad_fn` | retained graph memory |
|---|---|---|
| 1 | 3,906 | 645 MB |
| 2 | 7,796 | 1,246 MB |
| 3 | 11,686 | 1,847 MB |

~600 MB retained per request, perfectly linear — a serving process OOMs after a handful of table requests (we hit this in production after ~7 requests before patching).

## Fix

One line: decorate `__call__` with `@torch.inference_mode()`. With the patch, retained graph tensors after every call: **0** (same measurement), outputs identical. We have been running this patch in a production table-structure service under sustained load with flat memory.

Happy to adjust if you'd prefer `torch.no_grad()` or an engine-level fix (e.g. `requires_grad_(False)` at load) instead — `inference_mode` on the entry point seemed the most robust since it also covers the cache tensors.